### PR TITLE
Add an option to restrict checks to just changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,8 @@
 
 A GitHub action for running the
 [18F configuration of ESLint](https://github.com/18F/18f-eslint) on your project
-nice and easily. Here's a sample workflow to get you started, or visit GitHub's
-[documentation on workflow syntax](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions)
-for more information.
-
-The simplest way to get this action installed into your repo is by using the
-action installer:
+nice and easily. The simplest way to get this action installed into your repo is
+by using the action installer:
 
 ```shell
 npx -p @18f/18f-eslint install-action
@@ -15,7 +11,7 @@ npx -p @18f/18f-eslint install-action
 
 (**NOTE** the `-p` - this is required in order to run non-default commands.)
 
-This commend will begin at the root of your git repo, walk through your
+This command will begin at the root of your git repo, walk through your
 directory tree looking for `package.json` files, and add a step to lint the
 directories where each one is located. Once the basic action is installed, you
 can then go tweak the configuration.
@@ -56,10 +52,18 @@ property in the `uses` block for the action:
     working-directory: src
 ```
 
-| variable          | default | what it does                                                                                                    |
-|-------------------|---------|-----------------------------------------------------------------------------------------------------------------|
-| lint-glob         | `.`     | Indicates what files to run eslint on. This is any single glob that eslint supports.                            |
-| working-directory | `.`     | Indicates where install [@18f/18f-eslint](https://npm.im/@18f/18f-eslint). This path must include package.json. |
+| variable          | default | what it does                                                                                                       |
+|-------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| lint-glob         | `.`     | Indicates what files to run eslint on. This is any single glob that eslint supports.                               |
+| only-changed      | `false` | Indicates whether to only run eslint on changed files. Must be `true` to enable. This will override `lint-glob`.   |
+| working-directory | `.`     | Indicates where to install [@18f/18f-eslint](https://npm.im/@18f/18f-eslint). This path must include package.json. |
+
+The `only-changed` variable is useful for existing project, so you can apply
+eslint only on files as you change them rather than having to update the whole
+project at once. Incremental linting!
+
+Visit GitHub's [documentation on workflow syntax](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions)
+for more information about configuring your workflow.
 
 ## Notes about action refs
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ property in the `uses` block for the action:
     working-directory: src
 ```
 
-| variable          | default | what it does                                                                                                       |
-|-------------------|---------|--------------------------------------------------------------------------------------------------------------------|
-| lint-glob         | `.`     | Indicates what files to run eslint on. This is any single glob that eslint supports.                               |
-| only-changed      | `false` | Indicates whether to only run eslint on changed files. Must be `true` to enable. This will override `lint-glob`.   |
-| working-directory | `.`     | Indicates where to install [@18f/18f-eslint](https://npm.im/@18f/18f-eslint). This path must include package.json. |
+| variable          | default | what it does                                                                                                                                   |
+|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| lint-glob         | `.`     | Indicates what files to run eslint on. This is any single glob that eslint supports.                                                           |
+| only-changed      | `false` | Indicates whether to only run eslint on changed files. Must be `true` to enable. This will override `lint-glob`.                               |
+| working-directory | `.`     | Indicates where to install [@18f/18f-eslint](https://npm.im/@18f/18f-eslint). This must be the directory where your `package.json` is located. |
 
 The `only-changed` variable is useful for existing projects, so you can apply
 eslint only on files as you change them rather than having to update the whole

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ property in the `uses` block for the action:
 | only-changed      | `false` | Indicates whether to only run eslint on changed files. Must be `true` to enable. This will override `lint-glob`.   |
 | working-directory | `.`     | Indicates where to install [@18f/18f-eslint](https://npm.im/@18f/18f-eslint). This path must include package.json. |
 
-The `only-changed` variable is useful for existing project, so you can apply
+The `only-changed` variable is useful for existing projects, so you can apply
 eslint only on files as you change them rather than having to update the whole
 project at once. Incremental linting!
 

--- a/action.sh
+++ b/action.sh
@@ -22,19 +22,22 @@ if [ $3 == "true" ]; then
   # bail out in that case, so temporarily allow the script to continue even if
   # there is a non-zero exit.
   set +e
+
+  # Get just the JS files that have changed. We're searching on file extensions,
+  # and we include a few that come up from time to time in our projects. We have
+  # to filter this list down because eslint doesn't have an option to ignore
+  # files it doesn't understand and it'll just complain.
   CHANGED=$(
     git diff --diff-filter=ACMR --name-only --relative origin/${GIT_MAIN} -- . |
     grep -e \.js$ -e \.jsx$ -e \.es6$
   )
+
+  # Now back to bailing out if there's an error.
   set -e
 
   if [ -n "$CHANGED" ]; then
     npm install @18f/18f-eslint@^1.1.0
 
-    # Get just the JS files that have changed. We're searching on file extensions,
-    # and we include a few that come up from time to time in our projects. We have
-    # to filter this list down because eslint doesn't have an option to ignore files
-    # it doesn't understand
     npx @18f/18f-eslint $(
       echo $CHANGED |
       xargs

--- a/action.sh
+++ b/action.sh
@@ -29,7 +29,7 @@ if [ $3 == "true" ]; then
   # files it doesn't understand and it'll just complain.
   CHANGED=$(
     git diff --diff-filter=ACMR --name-only --relative origin/${GIT_MAIN} -- . |
-    grep -e "\.js$" -e "\.jsx$" -e "\.es6$"
+    grep -E "\.(js|jsx|es6)$"
   )
 
   # Now back to bailing out if there's an error.

--- a/action.sh
+++ b/action.sh
@@ -1,9 +1,49 @@
 #!/usr/bin/env bash
 
+# Args:
+# $1 - inputs.working-directory
+# $2 - inputs.lint-glob
+# $3 - inputs.only-changed
+
 set -e
 
+# Get into the right directory, using the working-directory input.
 cd $GITHUB_WORKSPACE
 cd $1
 
-npm install @18f/18f-eslint@^1.1.0
-npx @18f/18f-eslint $2
+# Get the main branch. Historically it defaulted to "master" but it is being
+# changed to "main". We should work in both cases.
+GIT_MAIN=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+
+if [ $3 == "true" ]; then
+  echo "Only checking changed files..."
+
+  # grep returns a non-zero code if it doesn't match anything. We don't want to
+  # bail out in that case, so temporarily allow the script to continue even if
+  # there is a non-zero exit.
+  set +e
+  CHANGED=$(
+    git diff --diff-filter=ACMR --name-only --relative origin/${GIT_MAIN} -- . |
+    grep -e \.js$ -e \.jsx$ -e \.es6$
+  )
+  set -e
+
+  if [ -n "$CHANGED" ]; then
+    npm install @18f/18f-eslint@^1.1.0
+
+    # Get just the JS files that have changed. We're searching on file extensions,
+    # and we include a few that come up from time to time in our projects. We have
+    # to filter this list down because eslint doesn't have an option to ignore files
+    # it doesn't understand
+    npx @18f/18f-eslint $(
+      echo $CHANGED |
+      xargs
+    )
+  else
+    echo "No files changed. Skipping."
+  fi
+else
+  # Do the lint
+  npm install @18f/18f-eslint@^1.1.0
+  npx @18f/18f-eslint $2
+fi

--- a/action.sh
+++ b/action.sh
@@ -29,7 +29,7 @@ if [ $3 == "true" ]; then
   # files it doesn't understand and it'll just complain.
   CHANGED=$(
     git diff --diff-filter=ACMR --name-only --relative origin/${GIT_MAIN} -- . |
-    grep -e \.js$ -e \.jsx$ -e \.es6$
+    grep -e "\.js$" -e "\.jsx$" -e "\.es6$"
   )
 
   # Now back to bailing out if there's an error.

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,16 @@
 name: 18F eslint
 description: Runs eslint using the 18F standard configuration on a set of files
 inputs:
-  working-directory:
-    description: The working directory to begin from. This should be the directory that contains your package.json.
-    required: false
-    default: .
   lint-glob:
     description: Path glob to run eslint against. Defaults to the project root if empty.
+    required: false
+    default: .
+  only-changed:
+    description: Whether to limit linting to just the changed files. Must be "true" to enable. Overrides lint-glob, if provided.
+    required: false
+    default: false
+  working-directory:
+    description: The working directory to begin from. This should be the directory that contains your package.json.
     required: false
     default: .
 runs:
@@ -15,3 +19,4 @@ runs:
   args:
     - ${{ inputs.working-directory }}
     - ${{ inputs.lint-glob }}
+    - ${{ inputs.only-changed }}


### PR DESCRIPTION
- Adds the `only-changed` input, which causes the action to only lint files that have changed from the main git branch.
- closes #1

Release v1.1.0 after merging.